### PR TITLE
4.13 compatibility

### DIFF
--- a/Plugins/VRGesturePlugin/Source/VRGesturePlugin/Private/VRGestureRecognitionComponent.cpp
+++ b/Plugins/VRGesturePlugin/Source/VRGesturePlugin/Private/VRGestureRecognitionComponent.cpp
@@ -40,10 +40,8 @@ void UVRGestureRecognitionComponent::TickComponent( float DeltaTime, ELevelTick 
 {
 	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
 
-	if (GetOwner() && GestureRecognizer && AttachParent)
+	if (GetOwner() && GestureRecognizer)
 	{
-		//FVector Offset = AttachParent->RelativeRotation.RotateVector(OffsetInput);
-		//FVector Position = AttachParent->GetRelativeTransform().GetLocation() + Offset;
 		FVector Position = this->GetComponentLocation();
 		GestureRecognizer->Tick(Position);
 	}


### PR DESCRIPTION
"AttachParent" was already deprecated in 4.12, now the variable is private. But as its not used anyway, just throwed it away.
